### PR TITLE
Added alternative to binding icons manually.

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,18 @@ export class ExampleComponent {
 
 If you are doing this kind of complex processing, please import manually.
 
+Alternatively, if you have a limited number of icons you're binding to, you can add a block in your template as a "hint." 
+
+```html
+<!-- This is a trick to get ionic-angular-collect-icons
+     to include the icons, but it will never render. -->
+@if(false) {
+  <ion-icon name="home"></ion-icon>
+  <ion-icon name="people"></ion-icon>
+}
+```
+It's not ideal, but it will help to maintain the automation. 
+
 - Why not addIcons in each component?
 
 This is to minimize diffs by libraries. I did not like to have every component change on every run. I wanted to keep the diff as small as possible.


### PR DESCRIPTION
Added a simple example block of code you can add to your app.component.html to trick the script into importing icons that it might otherwise miss.