### PR TITLE
fix: detect hoisted Ionic packages with --project-path

### DIFF
--- a/src/utils/package-utils.test.ts
+++ b/src/utils/package-utils.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { existsSync } from "node:fs";
 import { readFile } from "node:fs/promises";
+import { join, resolve } from "node:path";
 
 import { getActualPackageVersion } from "./package-utils";
 
@@ -24,7 +25,7 @@ describe("getActualPackageVersion", () => {
   });
 
   it("should return null if package.json cannot be read", async () => {
-    vi.mocked(existsSync).mockResolvedValue(true);
+    vi.mocked(existsSync).mockReturnValue(true);
     vi.mocked(readFile).mockRejectedValue(new Error("Invalid JSON"));
 
     const actual = await getActualPackageVersion("validDir", "@ionic/angular");
@@ -33,11 +34,55 @@ describe("getActualPackageVersion", () => {
   });
 
   it("should return the package version", async () => {
-    vi.mocked(existsSync).mockResolvedValue(true);
+    vi.mocked(existsSync).mockReturnValue(true);
     vi.mocked(readFile).mockResolvedValue(JSON.stringify({ version: "1.0.0" }));
 
     const actual = await getActualPackageVersion("validDir", "@ionic/angular");
 
     expect(actual).toBe("1.0.0");
+  });
+
+  it("should find a package hoisted above the project directory", async () => {
+    const workspaceDir = resolve("workspace");
+    const projectDir = join(workspaceDir, "projects", "mobile");
+    const hoistedPackageJson = join(
+      workspaceDir,
+      "node_modules",
+      "@ionic/angular",
+      "package.json",
+    );
+
+    vi.mocked(existsSync).mockImplementation(
+      (candidate) => candidate === hoistedPackageJson,
+    );
+    vi.mocked(readFile).mockResolvedValue(JSON.stringify({ version: "9.1.0" }));
+
+    const actual = await getActualPackageVersion(projectDir, "@ionic/angular");
+
+    expect(actual).toBe("9.1.0");
+    expect(readFile).toHaveBeenCalledWith(hoistedPackageJson, {
+      encoding: "utf-8",
+    });
+  });
+
+  it("should prefer the package installed in the project directory", async () => {
+    const workspaceDir = resolve("workspace");
+    const projectDir = join(workspaceDir, "projects", "mobile");
+    const projectPackageJson = join(
+      projectDir,
+      "node_modules",
+      "@ionic/angular",
+      "package.json",
+    );
+
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(readFile).mockResolvedValue(JSON.stringify({ version: "9.0.0" }));
+
+    await getActualPackageVersion(projectDir, "@ionic/angular");
+
+    expect(existsSync).toHaveBeenCalledTimes(1);
+    expect(readFile).toHaveBeenCalledWith(projectPackageJson, {
+      encoding: "utf-8",
+    });
   });
 });

--- a/src/utils/package-utils.ts
+++ b/src/utils/package-utils.ts
@@ -1,8 +1,11 @@
 import { existsSync } from "node:fs";
 import { readFile } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
 
 /**
- * Looks up the installed package version in the node_modules directory.
+ * Looks up the installed package version in the closest node_modules directory.
+ * Parent directories are also searched to support packages hoisted by npm
+ * workspaces and other multi-project setups.
  *
  * @param dir The project directory.
  * @param packageName The name of the package to lookup.
@@ -12,9 +15,30 @@ export const getActualPackageVersion = async (
   dir: string,
   packageName: string,
 ) => {
-  const packageJsonPath = `${dir}/node_modules/${packageName}/package.json`;
+  let currentDir = resolve(dir);
+  let packageJsonPath: string | null = null;
 
-  if (!existsSync(packageJsonPath)) {
+  while (packageJsonPath === null) {
+    const candidate = join(
+      currentDir,
+      "node_modules",
+      packageName,
+      "package.json",
+    );
+
+    if (existsSync(candidate)) {
+      packageJsonPath = candidate;
+      break;
+    }
+
+    const parentDir = dirname(currentDir);
+    if (parentDir === currentDir) {
+      break;
+    }
+    currentDir = parentDir;
+  }
+
+  if (!packageJsonPath) {
     return null;
   }
 


### PR DESCRIPTION
## Summary

- search ancestor `node_modules` directories when resolving installed package versions
- detect `@ionic/angular` hoisted to a workspace root for multi-project `--project-path` usage
- preserve nearest/project-local package precedence
- add regression coverage for hoisted and local package resolution

## Verification

- `npm test` (70 tests)
- `npm run lint`
- `npm run build`
- `git diff --check`

## Review

- manager review: approved
- independent acceptance review: approved